### PR TITLE
ルートを別ファイルに分ける

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:jpstockmemo2/views/edit_page.dart';
-import 'package:jpstockmemo2/views/list_page.dart';
+import 'package:jpstockmemo2/route/route_generator.dart';
 
 void main() {
   runApp(const MyApp());
@@ -16,10 +15,8 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      routes: {
-        '/': (context) => const ListPage(),
-        '/editpage': (context) => const EditPage(),
-      },
+      initialRoute: '/',
+      onGenerateRoute: RouteGenerator.generateRoute,
     );
   }
 }

--- a/lib/route/route_generator.dart
+++ b/lib/route/route_generator.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:jpstockmemo2/views/edit_page.dart';
+import 'package:jpstockmemo2/views/error_page.dart';
+import 'package:jpstockmemo2/views/list_page.dart';
+
+class RouteGenerator {
+  static Route<dynamic> generateRoute(RouteSettings settings) {
+    switch (settings.name) {
+      case '/':
+        return MaterialPageRoute(
+          builder: (_) => const ListPage(),
+        );
+      case '/editpage':
+        return MaterialPageRoute(
+          builder: (_) => const EditPage(),
+        );
+      default:
+        return MaterialPageRoute(
+          builder: (_) => const ErrorPage(),
+        );
+    }
+  }
+}

--- a/lib/views/error_page.dart
+++ b/lib/views/error_page.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class ErrorPage extends StatelessWidget {
+  const ErrorPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("ErrorPage"),
+      ),
+      body: const Center(
+        child: Text(
+          "ErrorPage",
+          style: TextStyle(
+            color: Colors.red,
+            fontSize: 40.0,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
main.dartのroutesをRouteGeneratorを使用してファイルroute_generator.dartを作成 routeディレクトリを作成してroute_generator.dartを移動
ルートエラー時に表示するエラーページを仮作成